### PR TITLE
Add link to icepyx4gedi project page

### DIFF
--- a/book/projects/index.md
+++ b/book/projects/index.md
@@ -17,4 +17,4 @@ Here is our current list of project for our {{dates}} {{ hackweek }} hackweek:
 
 | Project Name (with link to GitHub repo) | Short Description | Project Lead(s) |
 |:--------|:--------|:-----|
-| [Snow-Extrapolation](https://github.com/geo-smart/Snow-Extrapolation) | Goal: Improve National Snow Model (NSM) prediction performance in the Sierra Nevada mountains through domain constraints and the exploration of different ML algorithms. | Ryan Johnson |
+| [icepyx4gedi](https://github.com/ICESAT-2HackWeek/icepyx4gedi) | Goal: To create and/or extend methods and routines in the [`icepyx`](https://icepyx.readthedocs.io/en/latest) Python library to support GEDI footprint data products. | [Aaron Friesz](https://github.com/amfriesz) |


### PR DESCRIPTION
Link to project page at https://github.com/ICESAT-2HackWeek/icepyx4gedi

Project Kanban board is at https://github.com/orgs/ICESAT-2HackWeek/projects/12/views/2
Icepyx fork the team was working on https://github.com/ICESAT-2HackWeek/icepyx/issues